### PR TITLE
Remove alloc from defined classes

### DIFF
--- a/ext/rugged/rugged_blame.c
+++ b/ext/rugged/rugged_blame.c
@@ -264,6 +264,8 @@ static VALUE rb_git_blame_each(VALUE self)
 void Init_rugged_blame(void)
 {
 	rb_cRuggedBlame = rb_define_class_under(rb_mRugged, "Blame", rb_cObject);
+	rb_undef_alloc_func(rb_cRuggedBlame);
+
 	rb_include_module(rb_cRuggedBlame, rb_mEnumerable);
 
 	rb_define_singleton_method(rb_cRuggedBlame, "new", rb_git_blame_new, -1);

--- a/ext/rugged/rugged_blob.c
+++ b/ext/rugged/rugged_blob.c
@@ -694,6 +694,7 @@ void Init_rugged_blob(void)
 	id_read = rb_intern("read");
 
 	rb_cRuggedBlob = rb_define_class_under(rb_mRugged, "Blob", rb_cRuggedObject);
+	rb_undef_alloc_func(rb_cRuggedBlob);
 
 	rb_define_method(rb_cRuggedBlob, "size", rb_git_blob_rawsize, 0);
 	rb_define_method(rb_cRuggedBlob, "content", rb_git_blob_content_GET, -1);
@@ -712,6 +713,8 @@ void Init_rugged_blob(void)
 	rb_define_singleton_method(rb_cRuggedBlob, "merge_files", rb_git_blob_merge_files, -1);
 
 	rb_cRuggedBlobSig = rb_define_class_under(rb_cRuggedBlob, "HashSignature", rb_cObject);
+	rb_undef_alloc_func(rb_cRuggedBlobSig);
+
 	rb_define_singleton_method(rb_cRuggedBlobSig, "new", rb_git_blob_sig_new, -1);
 	rb_define_singleton_method(rb_cRuggedBlobSig, "compare", rb_git_blob_sig_compare, 2);
 }

--- a/ext/rugged/rugged_commit.c
+++ b/ext/rugged/rugged_commit.c
@@ -869,6 +869,7 @@ static VALUE rb_git_commit_create_with_signature(int argc, VALUE *argv, VALUE se
 void Init_rugged_commit(void)
 {
 	rb_cRuggedCommit = rb_define_class_under(rb_mRugged, "Commit", rb_cRuggedObject);
+	rb_undef_alloc_func(rb_cRuggedCommit);
 
 	rb_define_singleton_method(rb_cRuggedCommit, "create", rb_git_commit_create, 2);
 	rb_define_singleton_method(rb_cRuggedCommit, "create_to_s", rb_git_commit_create_to_s, 2);

--- a/ext/rugged/rugged_config.c
+++ b/ext/rugged/rugged_config.c
@@ -411,6 +411,8 @@ void Init_rugged_config(void)
 	 * Config
 	 */
 	rb_cRuggedConfig = rb_define_class_under(rb_mRugged, "Config", rb_cObject);
+	rb_undef_alloc_func(rb_cRuggedConfig);
+
 	rb_define_singleton_method(rb_cRuggedConfig, "new", rb_git_config_new, 1);
 
 	rb_define_singleton_method(rb_cRuggedConfig, "global", rb_git_config_open_default, 0);

--- a/ext/rugged/rugged_diff.c
+++ b/ext/rugged/rugged_diff.c
@@ -640,6 +640,7 @@ static VALUE rb_git_diff_sorted_icase_p(VALUE self)
 void Init_rugged_diff(void)
 {
 	rb_cRuggedDiff = rb_define_class_under(rb_mRugged, "Diff", rb_cObject);
+	rb_undef_alloc_func(rb_cRuggedDiff);
 
 	rb_define_method(rb_cRuggedDiff, "patch", rb_git_diff_patch, -1);
 	rb_define_method(rb_cRuggedDiff, "write_patch", rb_git_diff_write_patch, -1);

--- a/ext/rugged/rugged_index.c
+++ b/ext/rugged/rugged_index.c
@@ -1029,6 +1029,8 @@ void Init_rugged_index(void)
 	 * Index
 	 */
 	rb_cRuggedIndex = rb_define_class_under(rb_mRugged, "Index", rb_cObject);
+	rb_undef_alloc_func(rb_cRuggedIndex);
+
 	rb_define_singleton_method(rb_cRuggedIndex, "new", rb_git_index_new, -1);
 
 	rb_define_method(rb_cRuggedIndex, "count", rb_git_index_count, 0);

--- a/ext/rugged/rugged_patch.c
+++ b/ext/rugged/rugged_patch.c
@@ -383,6 +383,7 @@ static VALUE rb_git_diff_patch_header(VALUE self)
 void Init_rugged_patch(void)
 {
 	rb_cRuggedPatch = rb_define_class_under(rb_mRugged, "Patch", rb_cObject);
+	rb_undef_alloc_func(rb_cRuggedPatch);
 
 	rb_define_singleton_method(rb_cRuggedPatch, "from_strings", rb_git_patch_from_strings, -1);
 

--- a/ext/rugged/rugged_rebase.c
+++ b/ext/rugged/rugged_rebase.c
@@ -389,6 +389,7 @@ static VALUE rebase_operation_type(git_rebase_operation *operation)
 void Init_rugged_rebase(void)
 {
 	rb_cRuggedRebase = rb_define_class_under(rb_mRugged, "Rebase", rb_cObject);
+	rb_undef_alloc_func(rb_cRuggedRebase);
 
 	rb_define_singleton_method(rb_cRuggedRebase, "new", rb_git_rebase_new, -1);
 	rb_define_method(rb_cRuggedRebase, "next",  rb_git_rebase_next,  0);

--- a/ext/rugged/rugged_reference.c
+++ b/ext/rugged/rugged_reference.c
@@ -368,6 +368,7 @@ static VALUE rb_git_ref_is_tag(VALUE self)
 void Init_rugged_reference(void)
 {
 	rb_cRuggedReference = rb_define_class_under(rb_mRugged, "Reference", rb_cObject);
+	rb_undef_alloc_func(rb_cRuggedReference);
 
 	rb_define_singleton_method(rb_cRuggedReference, "valid_name?", rb_git_ref_valid_name, 1);
 

--- a/ext/rugged/rugged_remote.c
+++ b/ext/rugged/rugged_remote.c
@@ -743,6 +743,7 @@ static VALUE rb_git_remote_push(int argc, VALUE *argv, VALUE self)
 void Init_rugged_remote(void)
 {
 	rb_cRuggedRemote = rb_define_class_under(rb_mRugged, "Remote", rb_cObject);
+	rb_undef_alloc_func(rb_cRuggedRemote);
 
 	rb_define_method(rb_cRuggedRemote, "name", rb_git_remote_name, 0);
 	rb_define_method(rb_cRuggedRemote, "url", rb_git_remote_url, 0);

--- a/ext/rugged/rugged_repo.c
+++ b/ext/rugged/rugged_repo.c
@@ -2738,7 +2738,7 @@ static VALUE rb_git_repo_cherrypick_commit(int argc, VALUE *argv, VALUE self)
 
 /*
  *  call-seq: repo.diff_from_buffer(buffer) -> Rugged::Diff object
- *  
+ *
  *  Where +buffer+ is a +String+.
  *  Returns A Rugged::Diff object
  */
@@ -2764,6 +2764,7 @@ void Init_rugged_repo(void)
 	id_call = rb_intern("call");
 
 	rb_cRuggedRepo = rb_define_class_under(rb_mRugged, "Repository", rb_cObject);
+	rb_undef_alloc_func(rb_cRuggedRepo);
 
 	rb_define_singleton_method(rb_cRuggedRepo, "new", rb_git_repo_new, -1);
 	rb_define_singleton_method(rb_cRuggedRepo, "bare", rb_git_repo_open_bare, -1);
@@ -2817,7 +2818,7 @@ void Init_rugged_repo(void)
 	rb_define_method(rb_cRuggedRepo, "apply", rb_git_repo_apply, -1);
 
 	rb_define_method(rb_cRuggedRepo, "revert_commit", rb_git_repo_revert_commit, -1);
-	
+
 	rb_define_method(rb_cRuggedRepo, "diff_from_buffer", rb_git_diff_from_buffer, 1);
 
 	rb_define_method(rb_cRuggedRepo, "path_ignored?", rb_git_repo_is_path_ignored, 1);
@@ -2841,6 +2842,8 @@ void Init_rugged_repo(void)
 	rb_define_method(rb_cRuggedRepo, "fetch_attributes", rb_git_repo_attributes, -1);
 
 	rb_cRuggedOdbObject = rb_define_class_under(rb_mRugged, "OdbObject", rb_cObject);
+	rb_undef_alloc_func(rb_cRuggedOdbObject);
+
 	rb_define_method(rb_cRuggedOdbObject, "data",  rb_git_odbobj_data,  0);
 	rb_define_method(rb_cRuggedOdbObject, "len",  rb_git_odbobj_size,  0);
 	rb_define_method(rb_cRuggedOdbObject, "type",  rb_git_odbobj_type,  0);

--- a/ext/rugged/rugged_revwalk.c
+++ b/ext/rugged/rugged_revwalk.c
@@ -481,6 +481,8 @@ static VALUE rb_git_walker_each_oid(int argc, VALUE *argv, VALUE self)
 void Init_rugged_revwalk(void)
 {
 	rb_cRuggedWalker = rb_define_class_under(rb_mRugged, "Walker", rb_cObject);
+	rb_undef_alloc_func(rb_cRuggedWalker);
+
 	rb_define_singleton_method(rb_cRuggedWalker, "new", rb_git_walker_new, 1);
 	rb_define_singleton_method(rb_cRuggedWalker, "walk", rb_git_walk, -1);
 

--- a/ext/rugged/rugged_submodule.c
+++ b/ext/rugged/rugged_submodule.c
@@ -792,6 +792,7 @@ void Init_rugged_submodule(void)
 	id_update_none  = rb_intern("none");
 
 	rb_cRuggedSubmodule = rb_define_class_under(rb_mRugged, "Submodule", rb_cObject);
+	rb_undef_alloc_func(rb_cRuggedSubmodule);
 
 	rb_define_method(rb_cRuggedSubmodule, "finalize_add", rb_git_submodule_finalize_add, 0);
 

--- a/ext/rugged/rugged_tag.c
+++ b/ext/rugged/rugged_tag.c
@@ -225,6 +225,7 @@ void Init_rugged_tag(void)
 	rb_define_method(rb_cRuggedTag, "target", rb_git_tag_target, 0);
 
 	rb_cRuggedTagAnnotation = rb_define_class_under(rb_cRuggedTag, "Annotation", rb_cRuggedObject);
+	rb_undef_alloc_func(rb_cRuggedTagAnnotation);
 
 	rb_define_method(rb_cRuggedTagAnnotation, "message", rb_git_tag_annotation_message, 0);
 	rb_define_method(rb_cRuggedTagAnnotation, "name", rb_git_tag_annotation_name, 0);

--- a/ext/rugged/rugged_tree.c
+++ b/ext/rugged/rugged_tree.c
@@ -899,6 +899,8 @@ void Init_rugged_tree(void)
 	 * Tree
 	 */
 	rb_cRuggedTree = rb_define_class_under(rb_mRugged, "Tree", rb_cRuggedObject);
+	rb_undef_alloc_func(rb_cRuggedTree);
+
 	rb_define_method(rb_cRuggedTree, "count", rb_git_tree_entrycount, 0);
 	rb_define_method(rb_cRuggedTree, "count_recursive", rb_git_tree_entrycount_recursive, -1);
 	rb_define_method(rb_cRuggedTree, "length", rb_git_tree_entrycount, 0);
@@ -917,6 +919,8 @@ void Init_rugged_tree(void)
 	rb_define_private_method(rb_singleton_class(rb_cRuggedTree), "diff_tree_to_tree", rb_git_diff_tree_to_tree, 4);
 
 	rb_cRuggedTreeBuilder = rb_define_class_under(rb_cRuggedTree, "Builder", rb_cObject);
+	rb_undef_alloc_func(rb_cRuggedTreeBuilder);
+
 	rb_define_singleton_method(rb_cRuggedTreeBuilder, "new", rb_git_treebuilder_new, -1);
 	rb_define_method(rb_cRuggedTreeBuilder, "clear", rb_git_treebuilder_clear, 0);
 	rb_define_method(rb_cRuggedTreeBuilder, "[]", rb_git_treebuilder_get, 1);


### PR DESCRIPTION
This fixes the `warning: undefining the allocator of T_DATA class Rugged::Commit` warnings that are common in ruby 3.2 builds